### PR TITLE
[Perlpark] 3주차 문제 제출

### DIFF
--- a/perlpark/boj_15721.js
+++ b/perlpark/boj_15721.js
@@ -1,0 +1,40 @@
+/*
+ * BAEKJOON ONLINE JUDGE
+ * https://www.acmicpc.net
+ * Problem Number: 15721
+ * Level: Silver V
+ * Algorithm: Implementation / Bruteforcing / Simulation
+ */
+
+/* Pseudocode *
+n = 1에서 시작
+0101(0 n번 반복)(1 n번 반복)이 번데기 송의 규칙이다.
+노래를 돌면서 찾아야 하는 slogan과 일치하면 count를 증가시킨다.
+count가 찾아야하는 T번째와 같아지면 인덱스를 사람 수로 나누어 출력한다.
+노래를 다 돌았음에도 count가 찾아야하는 T번째보다 작을 경우 번데기 송을 n+1번 더 부른다.
+*/
+
+const [A, T, slogan] = `${require('fs').readFileSync('/dev/stdin')}`
+  .trim()
+  .split(/\n/);
+
+const rule = (n) => '0101' + '0'.repeat(n + 1) + '1'.repeat(n + 1);
+let song = '';
+
+findSloganIndex(1);
+
+function findSloganIndex(n) {
+  song += rule(n);
+
+  let count = 0;
+  for (const i in song) {
+    if (song[i] === slogan) count++;
+
+    if (count == T) {
+      console.log(i % A);
+      return;
+    }
+  }
+
+  if (count < T) findSloganIndex(n + 1);
+}

--- a/perlpark/boj_2798.js
+++ b/perlpark/boj_2798.js
@@ -1,0 +1,55 @@
+/*
+ * BAEKJOON ONLINE JUDGE
+ * https://www.acmicpc.net
+ * Problem Number: 2798
+ * Level: Bronze II
+ * Algorithm: Bruteforcing
+ */
+
+/* Pseudocode *
+주어진 카드를 정렬한 다음
+[0][1] ... [length-1]
+0, 1과 마지막 인덱스를 선택하여 반복문 시작
+카드가 겹치면 안되므로 b === a 또는 c === a || c === b일 때 해당 반복문을 건너뜀
+a, b, c 인덱스의 값을 합산하여 마지노선 m을 넘지 않으면서, biggest 설정된 값보다 크면 biggest에 다시 대입
+max에 c 인덱스를 대입하여 a, b 반복문이 불필요하게 c 인덱스 이상을 탐색하지 않도록 처리
+최종적으로 biggest 출력
+*/
+
+const [n, m, ...cards] = `${require('fs').readFileSync('/dev/stdin')}`
+  .trim()
+  .split(/\s/)
+  .map((v) => +v);
+
+cards.sort((a, b) => a - b);
+
+function sum(a, b, c) {
+  return cards[a] + cards[b] + cards[c];
+}
+
+function isAnswer(a, b, c) {
+  return sum(a, b, c) <= m;
+}
+
+let biggest = 0;
+let max = n - 1;
+
+for (let a = 0; a < max - 1; a++) {
+  for (let b = 1; b < max; b++) {
+    if (b === a) continue;
+
+    for (let c = max; c > -1; c--) {
+      if (c === a || c === b) continue;
+
+      if (isAnswer(a, b, c)) {
+        if (biggest < sum(a, b, c)) {
+          biggest = sum(a, b, c);
+          max = c;
+        }
+        break;
+      }
+    }
+  }
+}
+
+console.log(biggest);


### PR DESCRIPTION
### 공통 문제

- 문제 링크: https://www.acmicpc.net/problem/2798
- 풀이 여부: Y
- 설명: 세 개의 카드를 골라 가장 큰 합산을 찾아야 하는 문제였습니다. 최초에 작은 수 두 개, 큰 수 하나를 선택하여 반복문을 돌리는 식으로 구현했습니다. 불필요한 반복문을 건너뛰려고 continue나 break를 사용하고 반복문의 횟수를 제한했는데, 메모리나 시간이 절약된 것 같진 않더라구요.. 끙

### 개인 문제

- 문제 링크: https://www.acmicpc.net/problem/15721
- 풀이 여부: Y
- 설명: 번데기 송의 길이가 모자랄 경우 재귀를 통해 반복할 수 있게 처리했습니다. 찾아야 하는 "뻔" or "데기"가 몇 번째 인덱스에 있는지 찾는 건 for 문을 사용했는데, 계산식으로 대체할 수 있는 방법이 없었을까 싶습니다.

