### PR TITLE
[Perlpark] 12주차 문제 제출

### DIFF
--- a/perlpark/boj_10757.py
+++ b/perlpark/boj_10757.py
@@ -1,0 +1,16 @@
+"""
+ * BAEKJOON ONLINE JUDGE
+ * https://www.acmicpc.net
+ * Problem Number: 10757
+ * Level: Bronze V
+ * Algorithm: Mathematics / Implementation / Arithmetic / Arbitrary Precision / Big Integers
+"""
+
+""" Pseudocode *
+파이썬3는 큰 수를 위한 타입이 별도로 없으므로 input을 int 값으로만 변경하여 계산하면 됨
+"""
+
+import sys
+
+a, b = sys.stdin.readline().split()
+print(int(a) + int(b))

--- a/perlpark/프로그래머스_92341.js
+++ b/perlpark/프로그래머스_92341.js
@@ -1,0 +1,52 @@
+/*
+ * Programers
+ * https://school.programmers.co.kr
+ * Problem Number: 92341
+ * Level: 2
+ * Algorithm: String
+ */
+
+/* Pseudocode *
+records를 순회하며 history 배열에 차량번호를 숫자로 바꾼 인덱스에
+입차/출차 시간을 담을 수 있는 객체({ IN: 0, OUT: 0 })를 저장,
+입차 기록일 경우 IN += 시간을 분으로 계산한 number 값,
+출차 기록일 경우 OUT += 시간을 분으로 계산한 number 값을 저장한다.
+
+history 배열에서 빈 칸을 필터링한 뒤 map을 돌려 주차 시간을 계산(OUT - IN)한다.
+만약 OUT이 IN보다 작을 경우 23:59를 분으로 계산한 1439를 더해 계산한다.
+요금표 기준을 참고하여 계산된 요금만 담기게 반환한다.
+
+요금 계산은 다음과 같음
+if time <= fees[0] return fees[1];
+return fees[1] + Math.ceil((time - fees[0]) / fees[2]) * fees[3];
+*/
+
+function solution(fees, records) {
+    const history = [];
+  
+    records.forEach((rcd) => {
+      const [time, number, type] = rcd.split(' ');
+      const idx = +number;
+  
+      if (!history[idx]) history[idx] = { IN: 0, OUT: 0 };
+      history[idx][type] += timeToMinute(time);
+    });
+  
+    return history
+      .filter((v) => !!v)
+      .map((log) => {
+        if (log.OUT <= log.IN) log.OUT += 1439;
+        return timeToFee(log.OUT - log.IN);
+      });
+  
+    function timeToMinute(time) {
+      const [h, m] = time.split(':');
+      return +h * 60 + +m;
+    }
+  
+    function timeToFee(time) {
+      if (time <= fees[0]) return fees[1];
+      return fees[1] + Math.ceil((time - fees[0]) / fees[2]) * fees[3];
+    }
+  }
+  


### PR DESCRIPTION
### 공통 문제

- 문제 링크: https://school.programmers.co.kr/learn/courses/30/lessons/92341
- 풀이 여부: Y
- 설명:
```
records를 순회하며 history 배열에 차량번호를 숫자로 바꾼 인덱스에
입차/출차 시간을 담을 수 있는 객체({ IN: 0, OUT: 0 })를 저장,
입차 기록일 경우 IN += 시간을 분으로 계산한 number 값,
출차 기록일 경우 OUT += 시간을 분으로 계산한 number 값을 저장한다.

history 배열에서 빈 칸을 필터링한 뒤 map을 돌려 주차 시간을 계산(OUT - IN)한다.
만약 OUT이 IN보다 작을 경우 23:59를 분으로 계산한 1439를 더해 계산한다.
요금표 기준을 참고하여 계산된 요금만 담기게 반환한다.

요금 계산은 다음과 같음
if time <= fees[0] return fees[1];
return fees[1] + Math.ceil((time - fees[0]) / fees[2]) * fees[3];
```
history 배열에 empty 칸이 많이 생기기 때문에 고민을 했는데,
history를 객체로 만들어서 순회를 위해 다시 배열로 바꾸는 것보다 속도 면에선 오히려 성능이 좋더라구요.
자바스크립트는 내부적으로 배열 = 객체이기도 해서 큰 문제 없을 거 같아 그대로 진행했습니다!

### 개인 문제

- 문제 링크: https://www.acmicpc.net/problem/10757
- 풀이 여부: Y
- 설명: 파이썬3는 큰 수를 위한 타입이 별도로 없으므로 input을 int 값으로만 변경하여 계산하면 됨

